### PR TITLE
feat: add responsive design support for mobile devices

### DIFF
--- a/prompt-babbler-app/src/components/babbles/BabbleListItem.tsx
+++ b/prompt-babbler-app/src/components/babbles/BabbleListItem.tsx
@@ -32,10 +32,10 @@ export function BabbleListItem({ babble, onTogglePin }: BabbleListItemProps) {
           {babble.title}
         </Link>
       </td>
-      <td className="w-full py-2 pr-4">
+      <td className="hidden w-full py-2 pr-4 sm:table-cell">
         <TagList tags={babble.tags} />
       </td>
-      <td className="py-2 pr-2 whitespace-nowrap text-xs text-muted-foreground">
+      <td className="hidden py-2 pr-2 whitespace-nowrap text-xs text-muted-foreground sm:table-cell">
         {dateStr}
       </td>
       <td className="py-2 pr-2">

--- a/prompt-babbler-app/src/components/layout/Header.tsx
+++ b/prompt-babbler-app/src/components/layout/Header.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { NavLink } from 'react-router';
-import { Home, Mic, FileText } from 'lucide-react';
+import { Home, Mic, FileText, Menu, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { UserMenu } from '@/components/layout/UserMenu';
 import { ThemeToggle } from '@/components/layout/ThemeToggle';
 import { SearchBar } from '@/components/search/SearchBar';
+import { Button } from '@/components/ui/button';
 
 const navItems = [
   { to: '/', label: 'Home', icon: Home },
@@ -11,51 +13,92 @@ const navItems = [
   { to: '/templates', label: 'Templates', icon: FileText },
 ] as const;
 
+function NavItems({ onNavigate }: { onNavigate?: () => void }) {
+  return (
+    <>
+      {navItems.map(({ to, label, icon: Icon }) => (
+        <NavLink
+          key={to}
+          to={to}
+          end={to === '/'}
+          onClick={onNavigate}
+          className={({ isActive }) =>
+            cn(
+              'inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+            )
+          }
+        >
+          <Icon className="size-4" />
+          {label}
+        </NavLink>
+      ))}
+    </>
+  );
+}
+
 export function Header() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   return (
     <header className="border-b bg-background">
       <div className="mx-auto flex h-14 w-full max-w-7xl items-center gap-4 px-4">
-        {/* Left: Icon + Heading */}
-        <NavLink to="/" className="flex items-center gap-2">
+        {/* Brand */}
+        <NavLink to="/" className="flex shrink-0 items-center gap-2">
           <Mic className="size-5 text-primary" />
           <span className="gradient-brand text-lg font-bold tracking-tight">
             Prompt Babbler
           </span>
         </NavLink>
 
-        {/* Navigation */}
-        <nav className="flex items-center gap-1">
-          {navItems.map(({ to, label, icon: Icon }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={to === '/'}
-              className={({ isActive }) =>
-                cn(
-                  'inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                  isActive
-                    ? 'bg-accent text-accent-foreground'
-                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-                )
-              }
-            >
-              <Icon className="size-4" />
-              {label}
-            </NavLink>
-          ))}
+        {/* Desktop Navigation */}
+        <nav className="hidden items-center gap-1 sm:flex">
+          <NavItems />
         </nav>
 
-        {/* Center: Search */}
-        <div className="ml-auto mr-2 hidden sm:block">
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Desktop Search */}
+        <div className="mr-2 hidden sm:block">
           <SearchBar />
         </div>
 
-        {/* Right: Theme + User Menu */}
+        {/* Theme + User Menu */}
         <div className="flex items-center gap-2">
           <ThemeToggle />
           <UserMenu />
         </div>
+
+        {/* Mobile hamburger */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="sm:hidden"
+          onClick={() => setMobileMenuOpen((open) => !open)}
+          aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={mobileMenuOpen}
+        >
+          {mobileMenuOpen ? <X className="size-5" /> : <Menu className="size-5" />}
+        </Button>
       </div>
+
+      {/* Mobile navigation panel */}
+      {mobileMenuOpen && (
+        <nav
+          className="border-t px-4 py-3 sm:hidden"
+          aria-label="Mobile navigation"
+        >
+          <div className="flex flex-col gap-1">
+            <NavItems onNavigate={() => setMobileMenuOpen(false)} />
+          </div>
+          <div className="mt-3 pb-1">
+            <SearchBar />
+          </div>
+        </nav>
+      )}
     </header>
   );
 }

--- a/prompt-babbler-app/src/components/layout/Header.tsx
+++ b/prompt-babbler-app/src/components/layout/Header.tsx
@@ -24,7 +24,7 @@ function NavItems({ onNavigate }: { onNavigate?: () => void }) {
           onClick={onNavigate}
           className={({ isActive }) =>
             cn(
-              'inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+              'inline-flex items-center gap-2 rounded-md px-3 py-3 sm:py-2 text-sm font-medium transition-colors',
               isActive
                 ? 'bg-accent text-accent-foreground'
                 : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
@@ -76,7 +76,7 @@ export function Header() {
         <Button
           variant="ghost"
           size="icon"
-          className="sm:hidden"
+          className="h-11 w-11 sm:hidden"
           onClick={() => setMobileMenuOpen((open) => !open)}
           aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
           aria-expanded={mobileMenuOpen}

--- a/prompt-babbler-app/src/components/layout/UserMenu.tsx
+++ b/prompt-babbler-app/src/components/layout/UserMenu.tsx
@@ -58,7 +58,7 @@ function AuthenticatedUserMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="gap-2">
+        <Button variant="ghost" size="sm" className="gap-2" aria-label={displayName || 'User menu'}>
           <span className="flex size-6 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
             {getInitials(displayName)}
           </span>
@@ -103,6 +103,7 @@ function AnonymousUserMenu() {
           size="sm"
           className="gap-2 opacity-60"
           title="Entra ID SSO is not enabled. Running in anonymous single-user mode."
+          aria-label="Anonymous user menu"
         >
           <CircleUser className="size-5" />
           <span className="hidden text-sm sm:inline">Anonymous</span>

--- a/prompt-babbler-app/src/components/layout/UserMenu.tsx
+++ b/prompt-babbler-app/src/components/layout/UserMenu.tsx
@@ -62,7 +62,7 @@ function AuthenticatedUserMenu() {
           <span className="flex size-6 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
             {getInitials(displayName)}
           </span>
-          <span className="max-w-[120px] truncate text-sm">{displayName}</span>
+          <span className="hidden max-w-[120px] truncate text-sm sm:inline">{displayName}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
@@ -105,7 +105,7 @@ function AnonymousUserMenu() {
           title="Entra ID SSO is not enabled. Running in anonymous single-user mode."
         >
           <CircleUser className="size-5" />
-          <span className="text-sm">Anonymous</span>
+          <span className="hidden text-sm sm:inline">Anonymous</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">

--- a/prompt-babbler-app/src/components/templates/TemplateListItem.tsx
+++ b/prompt-babbler-app/src/components/templates/TemplateListItem.tsx
@@ -37,13 +37,13 @@ export function TemplateListItem({ template, onSelect }: TemplateListItemProps) 
           {template.isBuiltIn && <Badge variant="secondary">Built-in</Badge>}
         </div>
       </td>
-      <td className="w-full py-2 pr-4">
+      <td className="hidden w-full py-2 pr-4 sm:table-cell">
         <p className="line-clamp-2 text-xs text-muted-foreground">{template.description}</p>
       </td>
-      <td className="py-2 pr-4 whitespace-nowrap">
+      <td className="hidden py-2 pr-4 whitespace-nowrap sm:table-cell">
         <TagList tags={template.tags} />
       </td>
-      <td className="py-2 pr-2 whitespace-nowrap text-xs text-muted-foreground">
+      <td className="hidden py-2 pr-2 whitespace-nowrap text-xs text-muted-foreground sm:table-cell">
         {updatedAt}
       </td>
     </tr>

--- a/prompt-babbler-app/src/pages/BabblePage.tsx
+++ b/prompt-babbler-app/src/pages/BabblePage.tsx
@@ -288,7 +288,7 @@ export function BabblePage() {
             </p>
           </div>
         </div>
-        <div className="flex shrink-0 gap-2">
+        <div className="flex flex-wrap gap-2 sm:flex-nowrap sm:shrink-0">
           <Button asChild size="sm">
             <Link to={`/record/${babble.id}`}>
               <Mic className="size-4" />

--- a/prompt-babbler-app/src/pages/BabblePage.tsx
+++ b/prompt-babbler-app/src/pages/BabblePage.tsx
@@ -218,7 +218,7 @@ export function BabblePage() {
   return (
     <AuthGuard message="Sign in with your organizational account to view babbles.">
     <div className="space-y-6">
-      <div className="flex items-start justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <div className="flex items-center gap-2">
             {isEditingTitle ? (
@@ -288,7 +288,7 @@ export function BabblePage() {
             </p>
           </div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex shrink-0 gap-2">
           <Button asChild size="sm">
             <Link to={`/record/${babble.id}`}>
               <Mic className="size-4" />

--- a/prompt-babbler-app/src/pages/HomePage.tsx
+++ b/prompt-babbler-app/src/pages/HomePage.tsx
@@ -36,7 +36,7 @@ export function HomePage() {
   return (
     <AuthGuard message="Sign in with your organizational account to record babbles and generate prompts.">
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-2xl font-bold">Your Babbles</h1>
             <p className="text-sm text-muted-foreground">

--- a/prompt-babbler-app/src/pages/RecordPage.tsx
+++ b/prompt-babbler-app/src/pages/RecordPage.tsx
@@ -266,19 +266,21 @@ export function RecordPage() {
           />
         )}
 
-        <div className="flex items-center gap-4 rounded-lg border px-4 py-3">
-          <RecordButton
-            isRecording={isRecording}
-            onStart={handleStart}
-            onStop={handleStop}
-          />
-          <RecordingIndicator
-            isRecording={isRecording}
-            duration={duration}
-            hasTranscription={!!(transcribedText || existingBabble?.text)}
-          />
+        <div className="flex flex-col gap-3 rounded-lg border px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
+          <div className="flex items-center gap-4">
+            <RecordButton
+              isRecording={isRecording}
+              onStart={handleStart}
+              onStop={handleStop}
+            />
+            <RecordingIndicator
+              isRecording={isRecording}
+              duration={duration}
+              hasTranscription={!!(transcribedText || existingBabble?.text)}
+            />
+          </div>
           {!isAppendMode && !isRecording && (
-            <>
+            <div className="flex items-center gap-2">
               <span className="text-xs text-muted-foreground">or</span>
               <Button
                 disabled={isUploading}
@@ -298,7 +300,7 @@ export function RecordPage() {
                 className="hidden"
                 onChange={(e) => void handleFileSelect(e)}
               />
-            </>
+            </div>
           )}
           <WaveformVisualizer
             analyserRef={analyserRef}
@@ -320,7 +322,7 @@ export function RecordPage() {
           <p className="text-sm text-destructive">{transcriptionError}</p>
         )}
 
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Button
             onClick={() => void handleSave()}
             disabled={!transcribedText.trim() || !transcriptionDone || isSaving}

--- a/prompt-babbler-app/tests/components/layout/Header.test.tsx
+++ b/prompt-babbler-app/tests/components/layout/Header.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { Header } from '@/components/layout/Header';
+
+vi.mock('@/components/search/SearchBar', () => ({
+  SearchBar: () => <div data-testid="search-bar" />,
+}));
+
+vi.mock('@/components/layout/UserMenu', () => ({
+  UserMenu: () => <div data-testid="user-menu" />,
+}));
+
+vi.mock('@/components/layout/ThemeToggle', () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle" />,
+}));
+
+describe('Header', () => {
+  it('renders the brand name', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Prompt Babbler')).toBeInTheDocument();
+  });
+
+  it('renders the desktop navigation links', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /new babble/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /templates/i })).toBeInTheDocument();
+  });
+
+  it('renders the mobile menu toggle button', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
+  });
+
+  it('does not show mobile navigation panel by default', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+    expect(screen.queryByRole('navigation', { name: 'Mobile navigation' })).not.toBeInTheDocument();
+  });
+
+  it('opens mobile navigation panel when hamburger is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    expect(screen.getByRole('navigation', { name: 'Mobile navigation' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close menu' })).toBeInTheDocument();
+  });
+
+  it('closes mobile navigation panel when hamburger is clicked again', async () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Close menu' }));
+
+    expect(screen.queryByRole('navigation', { name: 'Mobile navigation' })).not.toBeInTheDocument();
+  });
+
+  it('closes mobile menu when a nav link is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const mobileNav = screen.getByRole('navigation', { name: 'Mobile navigation' });
+    const firstLink = mobileNav.querySelector('a');
+    expect(firstLink).not.toBeNull();
+    await userEvent.click(firstLink!);
+
+    expect(screen.queryByRole('navigation', { name: 'Mobile navigation' })).not.toBeInTheDocument();
+  });
+
+  it('shows search bar inside mobile navigation panel', async () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    const mobileNav = screen.getByRole('navigation', { name: 'Mobile navigation' });
+    expect(mobileNav.querySelector('[data-testid="search-bar"]')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements #145 — adds comprehensive mobile responsive design across the entire application.

## Changes

### Header — Mobile hamburger menu
- Extracts `NavItems` helper shared between desktop and mobile nav
- Desktop nav hidden on mobile (`hidden sm:flex`), hamburger shown (`sm:hidden`)
- Hamburger button toggles a collapsible nav panel below the header
- Mobile nav panel contains all nav links and the search bar
- Mobile menu auto-closes on nav link click
- Uses `flex-1` spacer to keep brand left and controls right on all screen sizes

### UserMenu — Compact on mobile
- Display name text hidden below `sm` breakpoint (`hidden sm:inline`)
- On mobile, only the avatar initials circle or anonymous icon is shown

### Pages — Stacked layouts on mobile
- **BabblePage**: title area and action buttons (`Continue`, `Edit`, `Delete`) stack vertically on mobile (`flex-col sm:flex-row`)
- **RecordPage**: recording controls area stacks vertically on mobile — record button/indicator grouped together, upload section on its own row; save button row wraps on mobile
- **HomePage**: title/description and "New Babble" button stack vertically on mobile

### List items — Responsive table columns
- **BabbleListItem**: tags and date columns hidden on mobile (`hidden sm:table-cell`)
- **TemplateListItem**: description, tags, and date columns hidden on mobile

### Tests
- New `Header.test.tsx` with 8 tests covering: brand render, desktop nav links, hamburger button presence, mobile menu open/close, auto-close on nav click, search bar in mobile panel
- All 159 tests pass ✅, lint passes ✅

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PlagueHO/prompt-babbler/217)
<!-- Reviewable:end -->
